### PR TITLE
Enabling work to support a Cygwin branch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,9 @@ on:
   - push
   - pull_request
 
+env:
+  CHERE_INVOKING: 1
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,9 +19,11 @@ jobs:
       # the target folder of the checkout action is removed
       - uses: actions/checkout@v2
         with:
-          repository: gap-packages/io
+          repository: gap-packages/profiling
       - uses: actions/checkout@v2
         with:
           path: this-action/
       - uses: gap-actions/setup-gap@v2
+        with:
+          GAP_PKGS_TO_BUILD: 'io'
       - uses: ./this-action/

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ inputs:
     description: 'set to 32 to use 32bit build flags for the package'
     required: false
     default: ''
+env:
+  CHERE_INVOKING: 1
 
 runs:
   using: "composite"


### PR DESCRIPTION
This is done for the same reasons as https://github.com/gap-actions/setup-gap/pull/34