### PR TITLE
GAP packages with configure support must support --with-gaproot=PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ All of the following inputs are optional.
  
 ### What's new in v3
 
+- Dropped support for GAP packages that have a `configure` script which does not
+  support the `--with-gaproot=PATH` argument.
 - The inputs `build-needed-pkgs`, `build-suggested-pkgs` and `build-extensions` were
   added. Setting these to `true` will also compile the relevant dependencies, and setting
   them to `recursive` will also compile the dependencies' dependencies, etc.

--- a/action.yml
+++ b/action.yml
@@ -86,12 +86,8 @@ runs:
         if [[ -x autogen.sh ]]; then
           ./autogen.sh
         fi
-        if grep Autoconf ./configure > /dev/null
-        then
+        if [[ -x configure ]]; then
           ./configure --with-gaproot=$GAPROOT ${{ inputs.CONFIGFLAGS }}
-          make -j4 V=1
-        elif [[ -x configure ]]; then
-          ./configure ${{ inputs.CONFIGFLAGS }} $GAPROOT
           make -j4 CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS"
         fi
 


### PR DESCRIPTION
... at least nowadays.

I guess this should be in a breaking release, just to be sure.