### PR TITLE
Don't invoke `BuildPackages.sh` with empty array as argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -239,5 +239,8 @@ runs:
             pkgdirs+=("${d#./}")
           done < <(find . -maxdepth 1 -type d -iname "${pkgdir}-*")
         done
-        
-        ../bin/BuildPackages.sh --strict ${pkgdirs[@]}
+
+        # Only run if array is nonempty, otherwise this tries to build all packages
+        if [[ -n ${pkgdirs[@]} ]]; then
+          ../bin/BuildPackages.sh --strict ${pkgdirs[@]}
+        fi


### PR DESCRIPTION
Or it tries to build every package. Not a good idea.