### PR TITLE
Actually complete renaming of CONFIGFLAGS to configflags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -213,7 +213,7 @@ runs:
           ./autogen.sh
         fi
         if [[ -x configure ]]; then
-          ./configure --with-gaproot=$GAPROOT ${{ inputs.CONFIGFLAGS }}
+          ./configure --with-gaproot=$GAPROOT ${{ inputs.configflags }}
           make -j4 CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS"
         fi
 


### PR DESCRIPTION
This was changed in v3 via PR #21 but then got accidentally reverted in PR #23.

I noticed this when I saw by chance that [Semigroups had updated to v3](https://github.com/semigroups/Semigroups/pull/1161) without renaming the `CONFIGFLAGS` input, yet this did not cause any regression; e.g. here is a [CI log from that PR](https://github.com/semigroups/Semigroups/actions/runs/23754570210/job/69205670977#step:9:255) which clearly shows that `CONFIGFLAGS` has an effect.

So... it seems GitHub Actions allows specifying a list of inputs, but that list in practice is almost completely useless: it does not prevent the user from passing in unsupported inputs, and we discovered in the past that its input validation is also unreliable *sigh*


Anyway: if we just merge and re-tag v3, this would break the Semigroups and Digraphs CI workflow. As far as I can tell, these are the only two which currently use the `CONFIGFLAGS` input. So, I can think of three options:

1. we merge this PR, and simultaneously update the CI of semigroups and Digraphs (on all their branches which use `gap-actions/build-pkg@v3` to use `configflags`)
2. we un-document that v3 renamed `CONFIGFLAGS` to `configflags` and redo it in v4 (or not at all, it's somewhat niche anyway)
3. we allow both `configflags` *and* `CONFIGFLAGS` (but without documenting it)


Would be good to hear what @james-d-mitchell thinks. None of this is his fault, so I'd like to minimize impact on him and his wonderful teams.