### PR TITLE
Run `apt-get update` before installing packages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -188,6 +188,7 @@ runs:
       shell: bash
       run: |
         if [[ "${{ runner.os }}" == "Linux" ]] && [[ -n "${SYS_PKGS_TO_BUILD}" ]]; then
+          sudo apt-get update
           sudo apt-get install --no-install-recommends ${SYS_PKGS_TO_BUILD}
         elif [[ "${{ runner.os }}" = "macOS" ]] && [[ -n "${SYS_PKGS_TO_BUILD}" ]]; then
           brew install ${SYS_PKGS_TO_BUILD}


### PR DESCRIPTION
Prevents the action from failing if the runner's apt caches are not up-to-date.